### PR TITLE
Move to winreg/WinReg.hpp

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
       win_64_:
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -35,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About winreg
-============
+About winreg-feedstock
+======================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/winreg-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/GiovanniDicanio/WinReg
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/winreg-feedstock/blob/main/LICENSE.txt)
 
 Summary: Convenient high-level C++ wrapper around the Windows Registry API
 
@@ -30,7 +30,7 @@ Current build status
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14681&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/winreg-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/winreg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: d4118ccfd4f4edee29e0f6b3706979791ad537278e2f74818c150bb66f8fcc53
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win]
-  script: cp WinReg\WinReg.hpp %LIBRARY_PREFIX%\include\
+  script: mkdir %LIBRARY_PREFIX%\include\winreg && cp WinReg\WinReg.hpp %LIBRARY_PREFIX%\include\winreg\
 
 test:
   commands:
-    - if not exist %LIBRARY_PREFIX%\include\WinReg.hpp (exit 1)  # [win]
+    - if not exist %LIBRARY_PREFIX%\include\winreg\WinReg.hpp (exit 1)  # [win]
 
 about:
   home: https://github.com/GiovanniDicanio/WinReg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

This makes the winreg path compatible with the vcpkg path for winreg, namely `include/winreg/WinReg.hpp`, see [here](https://github.com/microsoft/vcpkg/blob/ea222747b888b8d63df56240b262db38b095c68f/ports/winreg/portfile.cmake#L12). 

`winreg-feedstock` is only a dependency for mamba and micromamba, see [here](https://github.com/search?q=winreg+user%3Aconda-forge&type=code&ref=advsearch) so that should be relatively easy to fix in the next release. Just replace `#include <WinReg.hpp>` by `#include "winreg/WinReg.hpp"` and `find_path(WINREG_INCLUDE_DIR NAMES WinReg.hpp)` by `find_path(WINREG_INCLUDE_DIR NAMES "winreg/WinReg.hpp")`